### PR TITLE
 split onPagesLoaded in onPagesLoaded and onCurrentPageDiscovered

### DIFF
--- a/PicoPagesList.php
+++ b/PicoPagesList.php
@@ -1,13 +1,13 @@
 <?php
 /**
  * Flat and nested pages list navigation for Pico CMS.
- * 
+ *
  * - Adds twig global `{{ nested_pages }}` in addition to `{{ pages }}`
  * - Render flat or nested HTML navigation tree with `navigation` twig filter
  * - Filter pages and nested pages by paths with `exclude()` and `only()` twig filters
- * 
+ *
  * Examples :
- * 
+ *
  *     {{ pages | navigation }} // output a flat pages list
  *     {{ nested_pages | navigation }} // output a nested pages list
  *     {{ nested_pages | exclude('sub/page') | navigation }} // filtered nested pages list
@@ -25,7 +25,7 @@ class PicoPagesList extends AbstractPicoPlugin
     private $currentPagePath;
 
     /**
-     * Store the current url and construct the nested pages array.
+     * Construct the nested pages array.
      *
      * Triggered after Pico has read all known pages
      *
@@ -33,24 +33,37 @@ class PicoPagesList extends AbstractPicoPlugin
      * structure of the page data.
      *
      * @see    Pico::getPages()
+     * @param  array[] &$pages data of all known pages
+     * @return void
+     */
+    public function onPagesLoaded(array &$pages)
+    {
+        $this->items = $this->nestedPages($pages);
+    }
+
+
+    /**
+     * Store the current url.
+     *
+     * Triggered after Pico has found the current page and possible siblings
+     *
+     * See {@link DummyPlugin::onSinglePageLoaded()} for details about the
+     * structure of the page data.
+     *
      * @see    Pico::getCurrentPage()
      * @see    Pico::getPreviousPage()
      * @see    Pico::getNextPage()
-     * @param  array[]    &$pages        data of all known pages
      * @param  array|null &$currentPage  data of the page being served
      * @param  array|null &$previousPage data of the previous page
      * @param  array|null &$nextPage     data of the next page
      * @return void
      */
-    public function onPagesLoaded(
-        array &$pages,
+    protected function onCurrentPageDiscovered(
         array &$currentPage = null,
         array &$previousPage = null,
-        array &$nextPage = null
-    ) {
+        array &$nextPage = null) {
         $base_url = $this->getConfig('base_url');
         $this->currentPagePath = str_replace(array('?', $base_url), '', urldecode($currentPage['url']));
-        $this->items = $this->nestedPages($pages);
     }
 
     /**
@@ -68,7 +81,7 @@ class PicoPagesList extends AbstractPicoPlugin
     {
         $twig = $this->getPico()->getTwig();
         $twigVariables['nested_pages'] = $this->items;
-        
+
         $twig->addFilter(new Twig_SimpleFilter('navigation', function($pages) {
             return $this->output($pages);
         }));


### PR DESCRIPTION
pico 2.0 has a different parameter list for `onPagesLoaded`. the current page (and siblings) are not handed to `onPagesLoaded` anymore, there is a new function `onCurrentPageDiscovered`.