### PR TITLE
Fixing Twig Filters being added too late on latest Pico

### DIFF
--- a/PicoPagesList.php
+++ b/PicoPagesList.php
@@ -73,16 +73,11 @@ class PicoPagesList extends AbstractPicoPlugin
      * Triggered before Pico renders the page
      *
      * @see    Pico::getTwig()
-     * @see    DummyPlugin::onPageRendered()
-     * @param  string           &$templateName  file name of the template
-     * @param  array            &$twigVariables template variables
+     * @param  Twig_Environment &$twig Twig instance
      * @return void
      */
-    public function onPageRendering(string &$templateName, array &$twigVariables)
+    public function onTwigRegistered(Twig_Environment &$twig)
     {
-        $twig = $this->getPico()->getTwig();
-        $twigVariables['nested_pages'] = $this->items;
-
         $twig->addFilter(new Twig_SimpleFilter('navigation', function($pages) {
             return $this->output($pages);
         }));
@@ -94,6 +89,24 @@ class PicoPagesList extends AbstractPicoPlugin
         $twig->addFilter(new Twig_SimpleFilter('only', function($pages, array $paths = array()) {
             return $this->filterPages($pages, $paths, true);
         }, array('is_variadic' => true)));
+    }
+
+    /**
+     * Register `$this` in the Twig `{{ PagesList }}` variable.
+     *
+     * Triggered before Pico renders the page
+     *
+     * @see    Pico::getTwig()
+     * @see    DummyPlugin::onPageRendered()
+     * @param  string           &$templateName  file name of the template
+     * @param  array            &$twigVariables template variables
+     * @return void
+     */
+
+    public function onPageRendering(string &$templateName, array &$twigVariables)
+    {
+        $twig = $this->getPico()->getTwig();
+        $twigVariables['nested_pages'] = $this->items;
     }
 
     /**

--- a/PicoPagesList.php
+++ b/PicoPagesList.php
@@ -70,7 +70,6 @@ class PicoPagesList extends AbstractPicoPlugin
     /**
      * Register `$this` in the Twig `{{ PagesList }}` variable.
      *
-     * Triggered before Pico renders the page
      *
      * @see    Pico::getTwig()
      * @param  Twig_Environment &$twig Twig instance
@@ -105,7 +104,6 @@ class PicoPagesList extends AbstractPicoPlugin
 
     public function onPageRendering(string &$templateName, array &$twigVariables)
     {
-        $twig = $this->getPico()->getTwig();
         $twigVariables['nested_pages'] = $this->items;
     }
 


### PR DESCRIPTION
On my current Pico installation (2.0.4) I was not able to load this plugin, because apparently 'onPageRendering'  is too late to $twig->addFilter(new Twig_Simplefilter( ... )); it has to be done 'onTwigRegistered'.

I've tested this in my demo installation and it works as expected.