### PR TITLE
Incorporates PicoPlacing functionality

### DIFF
--- a/PicoPagesList.php
+++ b/PicoPagesList.php
@@ -79,6 +79,7 @@ class PicoPagesList extends AbstractPicoPlugin
      */
     public function onPagesLoaded(array &$pages)
     {
+        $aux = $pages;
         if ($config['page_order_by'] = 'placing') {
 
             $sorted_pages = array();
@@ -89,9 +90,9 @@ class PicoPagesList extends AbstractPicoPlugin
             }
 
             ksort($sorted_pages);
-            $pages = $sorted_pages;
+            $aux = $sorted_pages;
         }
-        $this->items = $this->nestedPages($pages);
+        $this->items = $this->nestedPages($aux);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -152,3 +152,7 @@ The lists are sorted according to the default settings in Pico `config.php`.
 pages_order_by: date
 pages_order: desc
 ```
+
+## Acknowledgements
+
+Includes functionality and code inspired by [PicoPlacing](https://github.com/ufgum/Pico-Placing).


### PR DESCRIPTION
The plugin [PicoPlacing](https://github.com/ufgum/Pico-Placing), which read a meta key `Placing` to reorder pages without having to rename them, didn't play along well with PicoPagesList; namely, PicoPagesList depended on PicoPlacing having already ordered the pages, but PicoPaging was choking on PicoPagesList `navigation` filter as it didn't know what to do of it.

As PicoPlacing hasn't been updated in a long while and it's barely a dozen lines, I decided to just mesh its functionality into PicoPagesList and fix a couple corner cases while at it. I thought you may like it upstream as well. It's completely optional (enabled by a `pages_order_by: placing` config), so there's no impact in your current features.